### PR TITLE
Fix defensive stat multiplier immunity handling

### DIFF
--- a/js/Stat.js
+++ b/js/Stat.js
@@ -26,15 +26,28 @@ function calculateStatMultiplier(offensiveCard, defensiveCard, stat) {
     }
 
     const statValue = getStatValue(offensiveCard, stat);
+
+    if (statValue === null || statValue === undefined) {
+        console.error('Invalid stat value');
+        return null;
+    }
+
     let statMultiplier = 1;
 
     if (['Attack', 'SpecialAttack'].includes(stat)) {
         statMultiplier = calculateTypeMultiplier(offensiveCard.type, defensiveCard.type);
     } else if (['Defense', 'SpecialDefense'].includes(stat)) {
-        statMultiplier = 1 / calculateTypeMultiplier(defensiveCard.type, offensiveCard.type);
+        const defensiveMultiplier = calculateTypeMultiplier(defensiveCard.type, offensiveCard.type);
+        statMultiplier = defensiveMultiplier === 0 ? Infinity : 1 / defensiveMultiplier;
     }
 
-    return parseInt(statValue * statMultiplier);
+    const boostedStat = statValue * statMultiplier;
+
+    if (!Number.isFinite(boostedStat)) {
+        return Infinity;
+    }
+
+    return Math.trunc(boostedStat);
 }
 
 


### PR DESCRIPTION
## Summary
- prevent defensive stat multipliers from becoming NaN when the opponent's attack type cannot hit
- guard against invalid stat lookups and keep integer rounding while allowing infinite multipliers

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d08a2c1bec832fa171e0788d645be9