### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -550,6 +550,19 @@ img {
         padding: 1rem;
     }
 
+    .app-shell {
+        gap: 1rem;
+    }
+
+    .table,
+    .menu {
+        padding: 1.25rem 1.5rem;
+    }
+
+    .table .row {
+        gap: 1rem;
+    }
+
     .badge {
         font-size: 0.8rem;
         padding: 0.5rem 1.2rem;
@@ -571,6 +584,135 @@ img {
 
     .packs {
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 0.75rem;
+    }
+
+    .table,
+    .menu {
+        padding: 1.1rem 1.35rem;
+    }
+
+    .header h1 {
+        font-size: 1.75rem;
+    }
+
+    .table .row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.85rem;
+    }
+
+    .row-auto {
+        align-items: center;
+    }
+
+    .col {
+        align-items: stretch;
+        text-align: center;
+    }
+
+    .badge {
+        align-self: center;
+    }
+
+    .stat-chip,
+    #your-type-name,
+    #opponent-type-name {
+        width: 100%;
+    }
+
+    .card {
+        min-height: 360px;
+        padding: 1.25rem;
+    }
+
+    .card img {
+        padding: 0.5rem;
+    }
+
+    .pokemon-label {
+        width: 100%;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .stat-options {
+        gap: 0.65rem;
+    }
+
+    .stat-options button {
+        font-size: 0.85rem;
+        padding: 0.65rem 0.9rem;
+    }
+
+    .primary-action {
+        margin-top: 1.25rem;
+        padding: 0.85rem 2rem;
+        font-size: 0.95rem;
+    }
+
+    .log {
+        min-height: 110px;
+        max-height: 180px;
+        padding: 0.85rem;
+    }
+
+    .menu-heading h2 {
+        font-size: 1.5rem;
+    }
+
+    .menu-heading p {
+        font-size: 0.95rem;
+    }
+
+    .pokemon-pack {
+        padding: 1rem;
+    }
+
+    .pokemon-pack img {
+        width: 90px;
+        height: 90px;
+    }
+
+    .rules,
+    .type-chart {
+        padding: 1.25rem;
+    }
+}
+
+@media (max-width: 380px) {
+    body {
+        padding: 0.5rem;
+    }
+
+    .header h1 {
+        font-size: 1.55rem;
+    }
+
+    .card {
+        min-height: 330px;
+        padding: 1.1rem;
+    }
+
+    .pokemon-label {
+        font-size: 0.85rem;
+    }
+
+    .stat-options button {
+        font-size: 0.8rem;
+    }
+
+    .primary-action {
+        font-size: 0.9rem;
+    }
+
+    .menu-heading p {
+        font-size: 0.9rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- reduce spacing on tablet and phone breakpoints to keep content within the viewport
- stack gameplay rows vertically on narrow screens and tighten card layout for handheld devices
- scale menu typography, controls, and imagery to remain legible and tappable on mobile

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1b996d3c8832f99b1b3d93b6dafba